### PR TITLE
fix: configure pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build:web
+      - uses: actions/configure-pages@v4
+        with:
+          enablement: true
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist/web


### PR DESCRIPTION
## Summary
- configure GitHub Pages before uploading artifact
- auto-enable Pages if not already set up

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bfdf59ddd0832ba01bb53c0be39f81